### PR TITLE
change install location from `~/.vim/` to `~/wptt-vim-config/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ I type DVORAK so some of my mappings may feel odd for you silly QWERTY people. I
 
 Change to your root directory `cd ~/` and then clone the repository.
 
-`git clone https://github.com/curtismchale/WPTT-Vim-Config.git .vim`
+`git clone https://github.com/curtismchale/WPTT-Vim-Config.git ~/wptt-vim-config`
 
-Install [Vundle](https://github.com/gmarik/Vundle.vim) by typing `git clone https://github.com/gmarik/Vundle.vim ~/.vim/bundle/vundle`
+Install [Vundle](https://github.com/gmarik/Vundle.vim) by typing `git clone https://github.com/gmarik/Vundle.vim ~/wptt-vim-config/bundle/vundle`
 
-Now use a symlink to point your .vimrc and .gvimrc files to the .gvimrc file inside the .vim folder. Back up your .gvimrc and .vimrc files if you aren't sure you want to make the jump with me.
+Now use a symlink to point your .vimrc and .gvimrc files to the .gvimrc file inside the wptt-vim-config folder. Back up your .gvimrc and .vimrc files if you aren't sure you want to make the jump with me.
 
-`ln -s .vim/.gvimrc .gvimrc && ln -s .vim/.gvimrc .vimrc`
+`ln -sf ~/wptt-vim-config/.gvimrc ~/.gvimrc && ln -sf ~/wptt-vim-config/.gvimrc ~/.vimrc && ln -sf ~/wptt-vim-config ~/.vim`
 
-Now all your vim/gvim configs are done in `.vim/.gvimrc`.
+Now all your vim/gvim configs are done in `~/wptt-vim-config/.gvimrc`.
 
 Open vim and then type `:BundleInstall` which tells Vundle to install all the bundles defined in your Vim config.
 


### PR DESCRIPTION
By installing the files in a separate directory, `~/wptt-vim-config/`, and then symlinking all three
- `.vimrc`
- `.gvimrc`
- `.vim/`

This makes it easier to switch between Vim configurations (by changing these three symlinks).

I can see this as more of a preference than a fix so I can understand declining this PR.  However, I've been very impressed with your Vim setup, particularly with your recent addition of Vundle, and I could see this repo becoming a great resource for other WordPress developers who want to get setup using Vim.  I think this change could make it easier for others who want to try out your configuration or switch between multiple configurations.

Thanks for sharing.
