### PR TITLE
change EOL and TAB invisibles

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -154,7 +154,7 @@ nmap k gk
 set tabstop=4                                           " a tab is four spaces
 set shiftwidth=4                                        " an autoindent (with <<) is four spaces
 set list                                                " show invisibles
-set listchars=eol:',tab:>-,trail:~,extends:>,precedes:< " decides what whitespace to shaw
+set listchars=eol:¬,tab:▸\ ,trail:~,extends:>,precedes:< " decides what whitespace to shaw
 set nowrap                                              " don't wrap lines
 set backspace=indent,eol,start                          " backspace through everything in insert mode
 


### PR DESCRIPTION
This is another change that is personal preference but as long as I'm making it in my fork, I wanted to offer it with my thoughts upstream.

I prefer these indicators because they do not show up regularly as characters I type.  I find the single quote for EOL particularly difficult because when I'm mid-string it gives me the false impressive I've already closed the string.
