### PR TITLE
Limit remove trailing whitespace by filetype

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -167,7 +167,7 @@ set backspace=indent,eol,start                          " backspace through ever
 set number
 set ruler
 
-autocmd BufWritePre * :%s/\s\+$//e    " remove trailing spaces on save
+autocmd FileType c,cpp,java,php,javascript autocmd BufWritePre * :%s/\s\+$//e    " remove trailing spaces on save
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Wild settings


### PR DESCRIPTION
Addresses Issue #30
Limit remove trailing whitespace automatically on save
by filetype. Only remove on these filetypes c,cpp,java,php,javascript
(i.e. whitelisting)

Motivation to add this restriction is markdown files specifically.

Based on http://vim.wikia.com/wiki/Remove_unwanted_spaces
