### PR TITLE
add shortcuts to change how tabs are handled

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -221,3 +221,16 @@ nnoremap <leader>sg :source $MYGVIMRC<cr>
 " takes the whatever is under the cursor and wraps it in error_log( and
 " print_r( with parameter true and a label
 autocmd FileType php nnoremap <leader>el ^vg_daerror_log( '<esc>pa=' . print_r( <esc>pa, true ) );<cr><esc>
+
+" Map <leader>ts2 to expand (t)abs to (s)paces with (2) characters indicating a tab
+nnoremap <leader>ts2 :set tabstop=2 softtabstop=2 shiftwidth=2 expandtab<CR>
+
+" Map <leader>ts4 to expand (t)abs to (s)paces with (4) characters indicating a tab
+nnoremap <leader>ts4 :set tabstop=4 softtabstop=4 shiftwidth=4 expandtab<CR>
+
+" Map <leader>tt2 to (t)abs to be treated as (t)ab characters and display as (2) characters
+nnoremap <leader>tt2 :set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab<CR>
+
+" Map <leader>tt4 to (t)abs to be treated as (t)ab characters and display as (4) characters
+nnoremap <leader>tt4 :set tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab<CR>
+


### PR DESCRIPTION
Introduces mappings to quickly change how tabs are handled.  I find these mappings helpful when dealing with code that uses spaces rather than tabs and thought others might find it useful as well.

`<leader>ts2`, `<leader>ts4` (use spaces, not tabs with size 2 or 4 respectively)
`<leader>tt2`, `<leader>tt4` (use tabs, not spaces with size 2 or 4 respectively)
