### PR TITLE
Add - and $ as keyword characters

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -169,6 +169,15 @@ set ruler
 
 autocmd FileType c,cpp,java,php,javascript autocmd BufWritePre * :%s/\s\+$//e    " remove trailing spaces on save
 
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" => Modify word boundary characters
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" remove - as a word boundary (i.e. making a keyword character)
+set iskeyword+=-
+" remove $ as a word boundary (i.e. making a keyword character)
+set iskeyword+=$
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Wild settings
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
Add **-** and **$** as keyword characters (i.e. remove them
from the list of keyword boundardies). This makes `yw` more
powerful when used in the context of variables, hook names, and css
class names.

**Original behavior**
Performing `yw` from the first character of `$varname` would
copy `$` only to the buffer.

Performing `yw` from the first character of `long-desc-class-name` would
copy `long` only to the buffer.

**Modified Behavior**
The buffers after `yw` would be `$varname` and `long-desc-class-name` respectively.
