### PR TITLE
Add case sensitive search

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -83,6 +83,8 @@ set statusline+=\ %P                    " percent through file
 """""""""""""""""""""""""""
 " ignore case when searching
 set ignorecase
+" ...unless the search uses uppercase letters
+set smartcase
 
 " highlight search results
 set hlsearch


### PR DESCRIPTION
Add case sensitive search when one or more of the characters in the search term
is a capital letter. (i.e. all lower case searches are case insensitive but any 
upper case characters makes it case sensitive)

http://vimdoc.sourceforge.net/htmldoc/usr_27.html#27.1
