### PR TITLE
Improvements to trailing whitespace handling

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -184,7 +184,7 @@ augroup END
 " add command :WWS
 " Write With Spaces - allows the write command to execute while suspending
 " autocmd (i.e. saves without regexp to remove trailing spaces)
-command WWS noautocmd w
+command! WWS noautocmd w
 
 autocmd FileType *.md set wrap|set linebreak|set nolist
 


### PR DESCRIPTION
Applies two changes:
1.  wraps autocmd for removing trailing whitespaces in an augroup block, as recommended by @sjl http://learnvimscriptthehardway.stevelosh.com/chapters/14.html#using-autocommands-in-your-vimrc
2.  Add a command `:WWS` to write while suspending autocmd, which allows the writing of a file without removing trailing whitespace - see #64 
