### PR TITLE
replace plugin Smart-Tabs with vim-easy-align

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -18,7 +18,7 @@ Bundle 'tsaleh/vim-align'
 Bundle 'tobyS/vmustache'
 Bundle 'tobyS/pdv'
 Bundle 'scrooloose/nerdcommenter'
-Bundle 'vim-scripts/Smart-Tabs'
+Bundle 'junegunn/vim-easy-align'
 Bundle 'editorconfig/editorconfig-vim'
 
 " Hints
@@ -235,9 +235,15 @@ inoremap jk <esc>
 " Map
 " :A $symbol
 " to
-" :Align $symbol
-" as a shortcut for vim-align plugin
-com! -bang -range -nargs=* A <line1>,<line2>call Align#Align(<bang>0,<q-args>)
+" :EasyAlign $symbol
+" as a shortcut for vim-easy-align plugin
+com! -bang -range -nargs=* A <line1>,<line2>call easy_align#align('<bang>' == '!', 0, '', <q-args>)
+
+" Map <Enter> in Visual Mode to Interactive EasyAlign (e.g. vip<Enter>)
+vmap <Enter> <Plug>(EasyAlign)
+
+" Map <leader>a to interactive EasyAlign for a motion/text object (e.g. <Leader>aip)
+nmap <Leader>a <Plug>(EasyAlign)
 
 " Map <leader>ev (i.e. \ev) to edit .vimrc
 " and <leader>sv to source (apply) .vimrc


### PR DESCRIPTION
The drive to make this swap was to correct the issue outlined in #57 but
overall I think this is an improvement. [EasyAlign plugin](https://github.com/junegunn/vim-easy-align/)

Reminder: you'll need to run `:BundleInstall!` to update your plugins after applying this code

Other modifications:
- Remap :A <symbol> to align on the symbol (as it did
  with Smart-Tabs).
- Add a mapping for <Enter> in visual mode that triggers EasyAlign
  interactive mode for the selected lines
- Add a mapping for <leader>a, which then takes a motion/text object
  that triggers EasyAlign interactive mode for the motion/text object
  (e.g. <leader>a5j will select 5 lines and  trigger EasyAlign
  interactive mode)

Fixes #57
